### PR TITLE
Appease GCC 8 diagnostic errors

### DIFF
--- a/binutils/objcopy.c
+++ b/binutils/objcopy.c
@@ -1932,11 +1932,11 @@ unbind_list_append (const char *cause, const char *sym)
   new_node->sym = strdup (sym);
 
   new_node->def_name = xmalloc (sizeof def_prefix + sym_len);
-  strncpy(new_node->def_name, def_prefix, sizeof def_prefix - 1);
+  strncpy(new_node->def_name, def_prefix, sizeof new_node->def_name - 1);
   strncpy(new_node->def_name + sizeof def_prefix - 1, sym, sym_len + 1);
 
   new_node->ref_name = xmalloc (sizeof ref_prefix + strlen(sym));
-  strncpy(new_node->ref_name, ref_prefix, sizeof ref_prefix - 1);
+  strncpy(new_node->ref_name, ref_prefix, sizeof new_node->ref_name - 1);
   strncpy(new_node->ref_name + sizeof ref_prefix - 1, sym, sym_len + 1);
 
   new_node->next = NULL;

--- a/binutils/wrstabs.c
+++ b/binutils/wrstabs.c
@@ -1440,18 +1440,15 @@ stab_end_struct_type (void *p)
 /* Start outputting a class.  */
 
 static bfd_boolean
-stab_start_class_type (void *p, const char *tag, unsigned int id, bfd_boolean structp, unsigned int size, bfd_boolean vptr, bfd_boolean ownvptr)
+stab_start_class_type (void *p, const char *tag, unsigned int id,
+		       bfd_boolean structp, unsigned int size,
+		       bfd_boolean vptr, bfd_boolean ownvptr)
 {
   struct stab_write_handle *info = (struct stab_write_handle *) p;
-  bfd_boolean definition;
-  char *vstring;
+  bfd_boolean definition = FALSE;
+  char *vstring = NULL;
 
-  if (! vptr || ownvptr)
-    {
-      definition = FALSE;
-      vstring = NULL;
-    }
-  else
+  if (vptr && !ownvptr)
     {
       definition = info->type_stack->definition;
       vstring = stab_pop_type (info);
@@ -1472,16 +1469,15 @@ stab_start_class_type (void *p, const char *tag, unsigned int id, bfd_boolean st
 	}
       else
 	{
+	  assert (vstring);
 	  vtable = (char *) xmalloc (strlen (vstring) + 3);
 	  sprintf (vtable, "~%%%s", vstring);
 	  free (vstring);
+	  if (definition)
+	    info->type_stack->definition = TRUE;
 	}
-
       info->type_stack->vtable = vtable;
     }
-
-  if (definition)
-    info->type_stack->definition = TRUE;
 
   return TRUE;
 }


### PR DESCRIPTION
GCC 8 (which is the default version on Debian buster) adds new string and format diagnostics, which require a few changes.

One change is unrelated to liballocs and is imported from upstream, and another is specific to the liballocs related changes in objcopy.